### PR TITLE
Extend to add repositories from Maven settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The plugin has been originally forked from https://github.com/rmanibus/gradle-ma
 - Plugin can be applied to Settings and Project scope. This includes support for mirror exclusions and profile
   activation.
 - Expose properties defined in Maven settings files to the Gradle scope.
+- Add `repository` and `pluginRepository` definitions from settings files to the Gradle scope.
 - Apply repository credentials defined in Maven settings files to Gradle:
     - DependencyResolution repositories - Settings and Project scope.
     - PluginManagement repositories - Settings scope only.
@@ -131,6 +132,13 @@ considered active. Active profiles are those listed in the `<activeProfiles>` se
 property of the `mavenSettings {...}` configuration closure, or those that satisfy the given profile's `<activation>`
 criteria.
 
+### Repositories
+
+Repositories defined within active profiles will be added to the Gradle scope and mirror definitions will be applied to
+them as well. Plugin repositories defined within active profiles will be added to the Gradle Settings scope
+pluginManagement repositories. The latter must be enabled explicitly via the `addPluginRepositories` property of the
+`mavenSettings {...}` configuration closure.
+
 ## Configuration
 
 Configuration of the Maven settings plugin is done via the `mavenSettings {...}` configuration closure. The following
@@ -142,6 +150,10 @@ properties are available.
 * `activeProfiles` - List of profile ids to treat as active.
 * `exportGradleProps` - Flag indicating whether or not Gradle project properties should be exported for the purposes of
   settings file property interpolation and profile activation. This defaults to `true`.
+* `addRepositories` - Flag indicating whether or not repositories defined in the settings file should be added to the
+  Gradle scope. This defaults to `true`.
+* `addPluginRepositories` - Flag indicating whether or not plugin repositories defined in the settings file should be
+  added to the Gradle Settings scope pluginManagement repositories. This defaults to `false`.
 * `mirrorExclusions` - List of repository names to be excluded from applying a mirror definition from settings.xml.
   This defaults to `['Gradle Central Plugin Repository', 'Google', 'MavenLocal', 'MavenCentralSnapshots']`.
 * `defaultMirrorExclusions` - Read-only property representing the default list of repository names to be excluded from

--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,17 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+// Compile compatibility with Java 8 for both Java and Groovy sources
+// to ensure that the plugin can be used in Gradle builds running on Java 8
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs << '-Xlint:-options'
+    options.release = "${project.targetCompatibility}".toInteger()
+}
+
+tasks.withType(GroovyCompile).configureEach {
+    options.compilerArgs << '-Xlint:-options'
+    sourceCompatibility = JavaVersion.toVersion("${project.sourceCompatibility}".toInteger())
+    targetCompatibility = JavaVersion.toVersion("${project.targetCompatibility}".toInteger())
 }
 
 // Get project properties as a Map for usage in processResources task to expand properties in **/*-expanded.properties files

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,8 @@
 group=io.github.mavenplugins.gradle
 version=1.1.0-SNAPSHOT
+####################################################################################################################
+# Java compiler
+sourceCompatibility=8
+targetCompatibility=8
+testSourceCompatibility=8
+testTargetCompatibility=8

--- a/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
+++ b/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
@@ -199,7 +199,7 @@ abstract class AbstractMavenSettingsPlugin {
     private void configureGradleRepoFromMavenRepo(MavenArtifactRepository gradleRepository, Repository mavenRepository) {
         gradleRepository.name = mavenRepository.id
         gradleRepository.url = new URI(mavenRepository.url)
-        if (mavenRepository.releases != null) {
+        if (mavenRepository.releases != null || mavenRepository.snapshots != null) {
             gradleRepository.mavenContent { content ->
                 boolean isReleaseEnabled = mavenRepository.releases == null || mavenRepository.releases.isEnabled()
                 boolean isSnapshotsEnabled = mavenRepository.snapshots == null || mavenRepository.snapshots.isEnabled()

--- a/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
+++ b/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
@@ -203,6 +203,11 @@ abstract class AbstractMavenSettingsPlugin {
             gradleRepository.mavenContent { content ->
                 boolean isReleaseEnabled = mavenRepository.releases == null || mavenRepository.releases.isEnabled()
                 boolean isSnapshotsEnabled = mavenRepository.snapshots == null || mavenRepository.snapshots.isEnabled()
+                if (!isReleaseEnabled && !isSnapshotsEnabled) {
+                    // Both releases and snapshots disabled - unusual configuration
+                    logger.warn("${logPrefix} Repository '${mavenRepository.id}' has both releases and snapshots disabled. This may indicate a configuration issue.")
+                    return
+                }
                 if (isReleaseEnabled && !isSnapshotsEnabled) {
                     content.releasesOnly()
                 }

--- a/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
+++ b/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
@@ -20,6 +20,7 @@ import groovy.transform.CompileStatic
 import io.github.mhoffrog.gradle.maven.settings.scope.IGradlePluginScopeUtilizer
 import io.github.mhoffrog.gradle.maven.settings.utils.PluginResourcesUtil
 import org.apache.maven.model.Profile
+import org.apache.maven.model.Repository
 import org.apache.maven.model.building.ModelProblemCollector
 import org.apache.maven.model.building.ModelProblemCollectorRequest
 import org.apache.maven.model.path.DefaultPathTranslator
@@ -149,11 +150,65 @@ abstract class AbstractMavenSettingsPlugin {
 
             }
         })
-
+        if (profiles.isEmpty()) {
+            logger.info("${logPrefix} No active Maven profiles.")
+            return
+        }
+        logger.info("${logPrefix} Active Maven profiles: ${profiles*.id.join(', ')}")
         profiles.each { profile ->
-            for (Entry entry : profile.properties) {
-                ExtensionContainer extensions = scopeUtilizer.extensions
-                extensions.getByType(ExtraPropertiesExtension).set(entry.key.toString(), entry.value.toString())
+            applyProfile(profile, extension)
+        }
+    }
+
+    private void applyProfile(Profile profile, MavenSettingsPluginExtension extension) {
+        logger.info("${logPrefix} Applying Maven profile ${profile.id}:")
+        for (Entry entry : profile.properties) {
+            ExtensionContainer extensions = scopeUtilizer.extensions
+            if (logger.isDebugEnabled()) {
+                logger.debug("${logPrefix}   Applying property '${entry.key}' with value '${entry.value}'.")
+            } else {
+                logger.info("${logPrefix}   Applying property '${entry.key}'.")
+            }
+            extensions.getByType(ExtraPropertiesExtension).set(entry.key.toString(), entry.value.toString())
+        }
+
+        if (extension.addRepositories) {
+            addGradleReposFromMavenRepos(profile, 'Dependency', scopeUtilizer.repositories, profile.repositories)
+        }
+        if (extension.addPluginRepositories) {
+            addGradleReposFromMavenRepos(profile, 'Plugin', scopeUtilizer.pluginManagementRepositories, profile.pluginRepositories)
+        }
+    }
+
+    private void addGradleReposFromMavenRepos(Profile profile, String repoType, RepositoryHandler gradleRepos, List<Repository> mavenRepos) {
+        if (gradleRepos == null) {
+            return
+        }
+        mavenRepos.each { mavenRepo ->
+            if (!gradleRepos*.name.contains(mavenRepo.id)) {
+                gradleRepos.maven { MavenArtifactRepository gradleRepo ->
+                    configureGradleRepoFromMavenRepo(gradleRepo, mavenRepo)
+                    logger.info("${logPrefix} Added ${repoType.toLowerCase()} repo '${mavenRepo.id}' '${mavenRepo.url}' from profile '${profile.id}' to Gradle ${scopeUtilizer.scopeName} scope.")
+                }
+            } else {
+                logger.info("${logPrefix} ${repoType} repo '${mavenRepo.id}' from profile '${profile.id}' is already defined in Gradle ${scopeUtilizer.scopeName} scope. Skipping to add.")
+            }
+        }
+    }
+
+    private void configureGradleRepoFromMavenRepo(MavenArtifactRepository gradleRepository, Repository mavenRepository) {
+        gradleRepository.name = mavenRepository.id
+        gradleRepository.url = new URI(mavenRepository.url)
+        if (mavenRepository.releases != null) {
+            gradleRepository.mavenContent { content ->
+                boolean isReleaseEnabled = mavenRepository.releases == null || mavenRepository.releases.isEnabled()
+                boolean isSnapshotsEnabled = mavenRepository.snapshots == null || mavenRepository.snapshots.isEnabled()
+                if (isReleaseEnabled && !isSnapshotsEnabled) {
+                    content.releasesOnly()
+                }
+                if (isSnapshotsEnabled && !isReleaseEnabled) {
+                    content.snapshotsOnly()
+                }
             }
         }
     }

--- a/src/main/groovy/net/linguica/gradle/maven/settings/MavenSettingsPluginExtension.groovy
+++ b/src/main/groovy/net/linguica/gradle/maven/settings/MavenSettingsPluginExtension.groovy
@@ -58,6 +58,18 @@ class MavenSettingsPluginExtension {
      */
     boolean exportGradleProps = true
 
+    /**
+     * Flag indicating whether or not repositories defined in the settings file should be added to the Gradle project.
+     * Defaults to true.
+     */
+    boolean addRepositories = true
+
+    /**
+     * Flag indicating whether or not plugin repositories defined in the settings file should be added to the Gradle pluginManagement.
+     * Defaults to false, as Maven plugin repositories are typically not needed for Gradle pluginManagement.
+     */
+    boolean addPluginRepositories = false
+
     MavenSettingsPluginExtension(IGradlePluginScopeUtilizer scopeUtilizer) {
         this.scopeUtilizer = scopeUtilizer
     }

--- a/src/test/groovy/net/linguica/gradle/maven/settings/test/MavenSettingsProjectPluginTest.groovy
+++ b/src/test/groovy/net/linguica/gradle/maven/settings/test/MavenSettingsProjectPluginTest.groovy
@@ -18,11 +18,13 @@ package net.linguica.gradle.maven.settings.test
 
 import io.github.mhoffrog.gradle.maven.settings.GradleConstants
 import net.linguica.gradle.maven.settings.MavenSettingsPlugin
-import org.apache.maven.settings.Mirror
-import org.apache.maven.settings.Profile
-import org.apache.maven.settings.Server
+import org.apache.maven.settings.*
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor
 import org.junit.jupiter.api.Test
+
+import java.util.function.Consumer
 
 import static org.assertj.core.api.Assertions.assertThat
 import static org.junit.jupiter.api.Assertions.assertEquals
@@ -311,6 +313,151 @@ class MavenSettingsProjectPluginTest extends AbstractMavenSettingsTest {
 
         assertThat(project.repositories.names).containsOnly(GradleConstants.GRADLE_MAVEN_LOCAL_REPO_NAME)
         assertThat(project.repositories*.url).containsOnly(getMavenLocalTestDir().toURI())
+    }
+
+    @Test
+    void shouldAddRepositoriesFromActiveProfiles() {
+        withMavenSettings {
+
+            profiles.add new Profile(id: "profile1",
+                    repositories: [new Repository(
+                            id: "repoFromProfile1",
+                            url: "http://maven.repo1.com",
+                            releases: new RepositoryPolicy(enabled: false))
+                    ])
+            profiles.add new Profile(id: "profile2",
+                    repositories: [new Repository(
+                            id: "repoFromProfile2",
+                            url: "http://maven.repo2.com")
+                    ])
+            profiles.add new Profile(id: "profile3",
+                    repositories: [new Repository(
+                            id: "repoFromProfile3",
+                            url: "http://maven.repo3.com")
+                    ])
+
+            servers.add new Server(id: "repoFromProfile2", username: TEST_USER_NAME, password: TEST_USER_PASSWORD)
+
+            activeProfiles = ["profile1", "profile2"]
+        }
+
+        addPluginWithSettings()
+
+        project.with {
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                maven {
+                    it.name = "custom1"
+                    it.url = uri("https://maven.custom.com")
+                }
+            }
+        }
+
+        project.evaluate()
+
+        //No profile 3, profile is not activated
+        assertThat(project.repositories.names).containsOnly(
+                "repoFromProfile1",
+                "repoFromProfile2",
+                GradleConstants.GRADLE_MAVEN_LOCAL_REPO_NAME,
+                GradleConstants.GRADLE_MAVEN_CENTRAL_REPO_NAME,
+                "custom1")
+
+        assertThat(project.repositories
+                .findAll { it instanceof MavenArtifactRepository }
+                .collect { (it as MavenArtifactRepository).url.toString() })
+                .contains(
+                        "https://repo.maven.apache.org/maven2/",
+                        "https://maven.custom.com",
+                        "http://maven.repo1.com",
+                        "http://maven.repo2.com"
+                )
+
+        // repoFromProfile1 has snapshots enabled
+        assertThat(project.repositories.getByName("repoFromProfile1") as MavenArtifactRepository)
+        // Note: .satisfies requires casting the argument to Consumer - s. https://github.com/assertj/assertj/issues/2357
+                .satisfies((Consumer) {
+                    it.content {
+                        assertThat((it as MavenRepositoryContentDescriptor).snapshotsOnly())
+                    }
+                })
+
+        assertThat(project.repositories.getByName("repoFromProfile2") as MavenArtifactRepository)
+        // Note: .satisfies requires casting the argument to Consumer - s. https://github.com/assertj/assertj/issues/2357
+                .satisfies((Consumer) {
+                    assertThat(it.credentials.username).isEqualTo(TEST_USER_NAME)
+                    assertThat(it.credentials.password).isEqualTo(TEST_USER_PASSWORD)
+                })
+    }
+
+    @Test
+    void mirrorsShouldOverrideReposWhenIdIsTheSame() {
+        withMavenSettings {
+
+            profiles.add new Profile(id: "profile1",
+                    repositories: [new Repository(
+                            id: "my.unique.repo",
+                            url: "http://maven.repo1.com"
+                    )])
+
+            mirrors.add new Mirror(id: "my.unique.repo", mirrorOf: "*", url: "http://maven.mirror.com")
+
+            activeProfiles = ["profile1"]
+        }
+
+        addPluginWithSettings()
+
+        project.with {
+            repositories {
+                mavenCentral()
+            }
+        }
+
+        project.evaluate()
+
+        // mirror should replace the one from profile (even with same id)
+        assertThat(project.repositories).hasSize(1).first()
+        // Note: .satisfies requires casting the argument to Consumer - s. https://github.com/assertj/assertj/issues/2357
+                .satisfies((Consumer) {
+                    assertThat((it as MavenArtifactRepository).name).isEqualTo("my.unique.repo")
+                    assertThat((it as MavenArtifactRepository).url).isEqualTo(new URI("http://maven.mirror.com"))
+                })
+    }
+
+    @Test
+    void shouldWorkWithReleaseOnlyProfile() {
+        withMavenSettings {
+
+            profiles.add new Profile(id: "profile1",
+                    repositories: [new Repository(
+                            id: "releaseOnly",
+                            url: "http://maven.repo1.com",
+                            releases: new RepositoryPolicy(enabled: true))
+                    ])
+
+            activeProfiles = ["profile1"]
+        }
+
+        addPluginWithSettings()
+
+        project.with {
+            pluginManager.apply("maven-publish")
+            repositories {
+                mavenCentral()
+            }
+        }
+
+        project.evaluate()
+
+        assertThat(project.repositories.names).containsOnly("releaseOnly", GradleConstants.GRADLE_MAVEN_CENTRAL_REPO_NAME)
+        assertThat(project.repositories.getByName("releaseOnly") as MavenArtifactRepository)
+        // Note: .satisfies requires casting the argument to Consumer - s. https://github.com/assertj/assertj/issues/2357
+                .satisfies((Consumer) {
+                    it.content {
+                        assertThat((it as MavenRepositoryContentDescriptor).releasesOnly())
+                    }
+                })
     }
 
 }

--- a/src/test/groovy/net/linguica/gradle/maven/settings/test/MavenSettingsProjectPluginTest.groovy
+++ b/src/test/groovy/net/linguica/gradle/maven/settings/test/MavenSettingsProjectPluginTest.groovy
@@ -323,7 +323,8 @@ class MavenSettingsProjectPluginTest extends AbstractMavenSettingsTest {
                     repositories: [new Repository(
                             id: "repoFromProfile1",
                             url: "http://maven.repo1.com",
-                            releases: new RepositoryPolicy(enabled: false))
+                            releases: new RepositoryPolicy(enabled: false),
+                            snapshots: new RepositoryPolicy(enabled: true))
                     ])
             profiles.add new Profile(id: "profile2",
                     repositories: [new Repository(
@@ -379,7 +380,8 @@ class MavenSettingsProjectPluginTest extends AbstractMavenSettingsTest {
         // Note: .satisfies requires casting the argument to Consumer - s. https://github.com/assertj/assertj/issues/2357
                 .satisfies((Consumer) {
                     it.content {
-                        assertThat((it as MavenRepositoryContentDescriptor).snapshotsOnly())
+                        assertThat(isReleasesOnly(it as MavenRepositoryContentDescriptor)).isFalse()
+                        assertThat(isSnapshotsOnly(it as MavenRepositoryContentDescriptor)).isTrue()
                     }
                 })
 
@@ -433,7 +435,8 @@ class MavenSettingsProjectPluginTest extends AbstractMavenSettingsTest {
                     repositories: [new Repository(
                             id: "releaseOnly",
                             url: "http://maven.repo1.com",
-                            releases: new RepositoryPolicy(enabled: true))
+                            releases: new RepositoryPolicy(enabled: true),
+                            snapshots: new RepositoryPolicy(enabled: false))
                     ])
 
             activeProfiles = ["profile1"]
@@ -455,7 +458,8 @@ class MavenSettingsProjectPluginTest extends AbstractMavenSettingsTest {
         // Note: .satisfies requires casting the argument to Consumer - s. https://github.com/assertj/assertj/issues/2357
                 .satisfies((Consumer) {
                     it.content {
-                        assertThat((it as MavenRepositoryContentDescriptor).releasesOnly())
+                        assertThat(isReleasesOnly(it as MavenRepositoryContentDescriptor)).isTrue()
+                        assertThat(isSnapshotsOnly(it as MavenRepositoryContentDescriptor)).isFalse()
                     }
                 })
     }

--- a/src/test/groovy/net/linguica/gradle/maven/settings/test/MavenSettingsProjectPluginTest.groovy
+++ b/src/test/groovy/net/linguica/gradle/maven/settings/test/MavenSettingsProjectPluginTest.groovy
@@ -445,7 +445,6 @@ class MavenSettingsProjectPluginTest extends AbstractMavenSettingsTest {
         addPluginWithSettings()
 
         project.with {
-            pluginManager.apply("maven-publish")
             repositories {
                 mavenCentral()
             }

--- a/src/test/groovy/net/linguica/gradle/maven/settings/test/common/AbstractCommonMavenSettingsTest.groovy
+++ b/src/test/groovy/net/linguica/gradle/maven/settings/test/common/AbstractCommonMavenSettingsTest.groovy
@@ -20,10 +20,14 @@ import io.github.mhoffrog.gradle.maven.settings.utils.PluginResourcesUtil
 import org.apache.maven.settings.io.DefaultSettingsWriter
 import org.apache.maven.settings.io.SettingsWriter
 import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor
+import org.gradle.api.internal.artifacts.repositories.DefaultMavenRepositoryContentDescriptor
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.io.TempDir
+
+import java.lang.reflect.Field
 
 abstract class AbstractCommonMavenSettingsTest {
 
@@ -89,6 +93,26 @@ abstract class AbstractCommonMavenSettingsTest {
         project.configure(mavenSettings, configureClosure)
         SettingsWriter writer = new DefaultSettingsWriter()
         writer.write(mavenSettingsFile, null, mavenSettings)
+    }
+
+    boolean isSnapshotsOnly(MavenRepositoryContentDescriptor contentDescriptor) {
+        return isMavenRepositoryContentDescriptorField(contentDescriptor, 'snapshots') && !isMavenRepositoryContentDescriptorField(contentDescriptor, 'releases')
+    }
+
+    boolean isReleasesOnly(MavenRepositoryContentDescriptor contentDescriptor) {
+        return isMavenRepositoryContentDescriptorField(contentDescriptor, 'releases') && !isMavenRepositoryContentDescriptorField(contentDescriptor, 'snapshots')
+    }
+
+    private static boolean isMavenRepositoryContentDescriptorField(MavenRepositoryContentDescriptor contentDescriptor, String fieldName) {
+        if (contentDescriptor.class.name != DefaultMavenRepositoryContentDescriptor.class.name) {
+            return false
+        }
+        if (fieldName != 'releases' && fieldName != 'snapshots') {
+            return false
+        }
+        Field field = contentDescriptor.class.getDeclaredField(fieldName)
+        field.setAccessible(true)
+        return (boolean) field.get(contentDescriptor)
     }
 
 }

--- a/src/test/groovy/net/linguica/gradle/maven/settings/test/common/AbstractCommonMavenSettingsTest.groovy
+++ b/src/test/groovy/net/linguica/gradle/maven/settings/test/common/AbstractCommonMavenSettingsTest.groovy
@@ -26,10 +26,12 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.io.TempDir
-
-import java.lang.reflect.Field
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 abstract class AbstractCommonMavenSettingsTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCommonMavenSettingsTest)
 
     protected static final String PLUGIN_ID = "${PluginResourcesUtil.pluginId}"
 
@@ -104,15 +106,18 @@ abstract class AbstractCommonMavenSettingsTest {
     }
 
     private static boolean isMavenRepositoryContentDescriptorField(MavenRepositoryContentDescriptor contentDescriptor, String fieldName) {
+        // instanceof does not work as the class may be loaded by a different classloader, so compare class names instead.
         if (contentDescriptor.class.name != DefaultMavenRepositoryContentDescriptor.class.name) {
             return false
         }
-        if (fieldName != 'releases' && fieldName != 'snapshots') {
-            return false
+        switch (fieldName) {
+            case 'releases':
+                return contentDescriptor.releases
+            case 'snapshots':
+                return contentDescriptor.snapshots
+            default:
+                throw new IllegalArgumentException("Unsupported field name: ${fieldName} of ${contentDescriptor.class.name} - Gradle internal API may have changed.")
         }
-        Field field = contentDescriptor.class.getDeclaredField(fieldName)
-        field.setAccessible(true)
-        return (boolean) field.get(contentDescriptor)
     }
 
 }


### PR DESCRIPTION
Repositories defined within active profiles will be added to the Gradle scope and mirror definitions will be applied to
them as well. Plugin repositories defined within active profiles will be added to the Gradle Settings scope
pluginManagement repositories. The latter must be enabled explicitly via the addPluginRepositories property of the
mavenSettings {...} configuration closure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maven settings repositories (including per-profile repos) can be exported into Gradle; plugin repositories can be exported separately and controlled independently.
  * Mirrors override repository URLs; releases/snapshots are preserved when mapping repository content.

* **Documentation**
  * README updated with repository/profile mapping and new configuration options.

* **Tests**
  * Added tests for repo export, mirror application, credentials, and release/snapshot policies.

* **Chores**
  * Java compiler compatibility and build task compiler settings standardized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->