### PR TITLE
Resolve properties in repo names and urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The plugin has been originally forked from https://github.com/rmanibus/gradle-ma
   `mirrorExclusions` property.
 - Apply `localRepository` from a `userSettingsFileName` configured settings file to the Gradle `MavenLocal` repo if
   `localRepository` is set in there. (Since plugin version `1.1.0`).
+- Resolution of repository name and/or repository URL from properties provided by `settings.xml`. (Since plugin version
+  `1.1.0`).
 
 ### Log Output
 
@@ -138,6 +140,32 @@ Repositories defined within active profiles will be added to the Gradle scope an
 them as well. Plugin repositories defined within active profiles will be added to the Gradle Settings scope
 pluginManagement repositories. The latter must be enabled explicitly via the `addPluginRepositories` property of the
 `mavenSettings {...}` configuration closure.
+
+### Resolution of properties in repository name and/or repository URL
+
+Properties defined in active profiles will be exported to the Gradle scope and can be used for repository names
+and for repository URL.
+For example, given the following profile definition in `settings.xml`:
+
+    <profiles>
+        <profile>
+            <id>myProfile</id>
+            <properties>
+                <repoName>myRepo</repoName>
+                <repoUrl>https://intranet.foo.org/repo</repoUrl>
+            </properties>
+        </profile>
+    </profiles>
+
+In a Gradle repository configuration these properties must be used with prefix `mavenSettings@`
+for the repository name and with prefix `https://mavenSettings@` for the repository URL as follows:
+
+    repositories {
+        maven {
+            name = 'mavenSettings@repoName' // property 'repoName' resolves to 'myRepo'
+            url = 'https://mavenSettings@repoUrl' // property 'repoUrl' resolves to 'https://intranet.foo.org/repo'
+        }
+    }
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -157,13 +157,13 @@ For example, given the following profile definition in `settings.xml`:
         </profile>
     </profiles>
 
-In a Gradle repository configuration these properties must be used with prefix `mavenSettings@`
-for the repository name and with prefix `https://mavenSettings@` for the repository URL as follows:
+In a Gradle repository configuration these properties must be used with prefix `maven-settings.` for the repository name
+and with prefix `https://maven-settings.` for the repository URL as follows:
 
     repositories {
         maven {
-            name = 'mavenSettings@repoName' // property 'repoName' resolves to 'myRepo'
-            url = 'https://mavenSettings@repoUrl' // property 'repoUrl' resolves to 'https://intranet.foo.org/repo'
+            name = 'maven-settings.repoName' // property 'repoName' resolves to 'myRepo'
+            url = 'https://maven-settings.repoUrl' // property 'repoUrl' resolves to 'https://intranet.foo.org/repo'
         }
     }
 

--- a/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
+++ b/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
@@ -47,7 +47,11 @@ import java.util.Map.Entry
 @CompileStatic
 abstract class AbstractMavenSettingsPlugin {
 
-    public static final String MAVEN_SETTINGS_EXTENSION_NAME = "mavenSettings"
+    public static final String MAVEN_SETTINGS_EXTENSION_NAME = 'mavenSettings'
+
+    public static final String MAVEN_SETTINGS_REPO_NAME_PROPERTY_PREFIX = MAVEN_SETTINGS_EXTENSION_NAME + '@'
+
+    public static final String MAVEN_SETTINGS_REPO_URL_PROPERTY_PREFIX = 'https://' + MAVEN_SETTINGS_REPO_NAME_PROPERTY_PREFIX
 
     private static final String LOG_PREFIX_TEMPLATE
 
@@ -82,17 +86,19 @@ abstract class AbstractMavenSettingsPlugin {
                     && !scopeUtilizer.publishingRepositoriesConfigured) {
                 logger.warn("${logPrefix} No repositories configured in ${scopeUtilizer.scopeName} scope. No repo credentials to apply.")
             } else {
+                resolvePropertiesForRepoNamesAndUrlsIfNeeded('PluginManagement', scopeUtilizer.pluginManagementRepositories)
+                resolvePropertiesForRepoNamesAndUrlsIfNeeded('DependencyResolution', scopeUtilizer.repositories)
+                resolvePropertiesForRepoNamesAndUrlsIfNeeded('Publishing', scopeUtilizer.publishingRepositories)
                 if (extension.isNonDefaultUserSettingsFileConfigured()) {
-                    [
-                            scopeUtilizer.pluginManagementRepositories,
-                            scopeUtilizer.repositories,
-                            scopeUtilizer.publishingRepositories
+                    [scopeUtilizer.pluginManagementRepositories,
+                     scopeUtilizer.repositories,
+                     scopeUtilizer.publishingRepositories
                     ].each { RepositoryHandler repos ->
                         applyMavenLocalFromUserSettingsFileConfigured(extension, repos)
                     }
                 }
-                registerMirrors(extension, scopeUtilizer.pluginManagementRepositories)
-                registerMirrors(extension, scopeUtilizer.repositories)
+                registerMirrors('PluginManagement', extension, scopeUtilizer.pluginManagementRepositories)
+                registerMirrors('DependencyResolution', extension, scopeUtilizer.repositories)
                 applyRepoCredentials('PluginManagement', scopeUtilizer.pluginManagementRepositories)
                 applyRepoCredentials('DependencyResolution', scopeUtilizer.repositories)
                 applyRepoCredentials('Publishing', scopeUtilizer.publishingRepositories)
@@ -247,17 +253,21 @@ abstract class AbstractMavenSettingsPlugin {
         }
     }
 
-    private void registerMirrors(MavenSettingsPluginExtension extension, RepositoryHandler repositories) {
+    private void registerMirrors(final String repoContext, MavenSettingsPluginExtension extension, RepositoryHandler repositories) {
         List<MavenArtifactRepository> reposToRemove = []
         Map<String, Mirror> mirrorsToAdd = new HashMap<>()
         repositories?.each { repo ->
             if (repo instanceof MavenArtifactRepository) {
-                if (extension.mirrorExclusions.contains(repo.name)) {
-                    logger.info("${logPrefix} Repository '${repo.name}' '${repo.url}' is excluded from mirror application by plugin configuration mirrorExclusions='${extension.mirrorExclusions.join(",")}'. Skipping.")
+                final String effectiveRepoName = resolveRepoPropertyIfNeeded(repoContext, repo.name) ?: repo.name
+                if (effectiveRepoName != repo.name) {
+                    logger.info("${logPrefix} Resolved ${repoContext} repository name '${repo.name}' to '${effectiveRepoName}' for mirror lookup.")
+                }
+                if (extension.mirrorExclusions.contains(effectiveRepoName)) {
+                    logger.info("${logPrefix} Repository '${effectiveRepoName}' '${repo.url}' is excluded from mirror application by plugin configuration mirrorExclusions='${extension.mirrorExclusions.join(",")}'. Skipping.")
                 } else {
-                    Mirror mirror = findMirrorMatchingForRepo(repo)
+                    Mirror mirror = findMirrorMatchingForRepo(repoContext, repo, effectiveRepoName)
                     if (mirror) {
-                        logger.info("${logPrefix} Repository '${repo.name}' '${repo.url}' is being replaced by mirror located at ${mirror.url} according to mirrorOf '${mirror.mirrorOf}'.")
+                        logger.info("${logPrefix} Repository '${effectiveRepoName}' '${repo.url}' is being replaced by mirror located at ${mirror.url} according to mirrorOf '${mirror.mirrorOf}'.")
                         mirrorsToAdd.put(mirror.id, mirror)
                         reposToRemove.add(repo)
                     }
@@ -275,7 +285,7 @@ abstract class AbstractMavenSettingsPlugin {
         }
     }
 
-    private Mirror findMirrorMatchingForRepo(final MavenArtifactRepository repo) {
+    private Mirror findMirrorMatchingForRepo(final String repoContext, final MavenArtifactRepository repo, final String effectiveRepoName) {
         for (Mirror mirror : mavenSettings.mirrors) {
             Mirror mirrorFound = null
             boolean isBreakMirrorOf = false
@@ -302,11 +312,11 @@ abstract class AbstractMavenSettingsPlugin {
                         }
                         break
                     default:
-                        if (mirrorOf == repo.name) {
+                        if (mirrorOf == effectiveRepoName) {
                             mirrorFound = mirror
                             isBreakMirrorOf = true
-                        } else if (mirrorOf == "!${repo.name}") {
-                            logger.info("${logPrefix} Repository '${repo.name}' '${repo.url}' is excluded from mirror '${resolveMirrorName(mirror)}' at '${mirror.url}' by mirrorOf '!${repo.name}'. Skipping.")
+                        } else if (mirrorOf == "!${effectiveRepoName}") {
+                            logger.info("${logPrefix} Repository '${effectiveRepoName}' '${repo.url}' is excluded from mirror '${resolveMirrorName(mirror)}' at '${mirror.url}' by mirrorOf '!${repo.name}'. Skipping.")
                             mirrorFound = null
                             isBreakMirrorOf = true
                         }
@@ -316,19 +326,61 @@ abstract class AbstractMavenSettingsPlugin {
                 }
             }
             if (mirrorFound) {
-                logger.info("${logPrefix} Repository '${repo.name}' '${repo.url}' matches mirrorOf '${mirrorFound.mirrorOf}' in mirror '${resolveMirrorName(mirrorFound)}' at '${mirrorFound.url}'.")
+                logger.info("${logPrefix} Repository '${effectiveRepoName}' '${repo.url}' matches mirrorOf '${mirrorFound.mirrorOf}' in mirror '${resolveMirrorName(mirrorFound)}' at '${mirrorFound.url}'.")
                 return mirrorFound
             }
         }
         return null
     }
 
+    private void resolvePropertiesForRepoNamesAndUrlsIfNeeded(final String repoContext, @Nullable RepositoryHandler repositories) {
+        repositories?.each { repo ->
+            if (repo instanceof MavenArtifactRepository) {
+                String newUrl = resolveRepoPropertyIfNeeded(repoContext, repo.url.toString())
+                if (newUrl) {
+                    try {
+                        URI newURI = new URI(newUrl)
+                        logger.info("${logPrefix} Updated repository '${repo.name}' with URI '${newURI}'.")
+                        repo.url = newURI
+                    } catch (URISyntaxException e) {
+                        throw new IllegalArgumentException("${logPrefix} Resolved ${repoContext} repository URL value '${newUrl}' is not a valid URI.", e)
+                    }
+                }
+            }
+        }
+    }
+
+    private String resolveRepoPropertyIfNeeded(final String repoContext, final String repoPropertyWithPrefix) {
+        String propertyName = null
+        if (repoPropertyWithPrefix.startsWith(MAVEN_SETTINGS_REPO_NAME_PROPERTY_PREFIX)) {
+            propertyName = repoPropertyWithPrefix.substring(MAVEN_SETTINGS_REPO_NAME_PROPERTY_PREFIX.length())
+        } else if (repoPropertyWithPrefix.startsWith(MAVEN_SETTINGS_REPO_URL_PROPERTY_PREFIX)) {
+            propertyName = repoPropertyWithPrefix.substring(MAVEN_SETTINGS_REPO_URL_PROPERTY_PREFIX.length())
+        } else {
+            return null
+        }
+        if (!propertyName) {
+            throw new IllegalArgumentException("${logPrefix} ${repoContext} Repository '${repoPropertyWithPrefix}' starts with a repo property prefix but no property name is specified after the prefix.")
+        }
+        String propertyValue = scopeUtilizer.properties[propertyName]?.toString()
+        if (propertyValue) {
+            logger.info("${logPrefix} Resolved ${repoContext} repository property '${propertyName}' with value '${propertyValue}'.")
+            return propertyValue
+        } else {
+            throw new IllegalArgumentException("${logPrefix} Unable to resolve ${repoContext} repository property '${propertyName}' for '${repoPropertyWithPrefix}'. No such property found in Gradle ${scopeUtilizer.scopeName} properties.")
+        }
+    }
+
     private void applyRepoCredentials(String repoContext, @Nullable RepositoryHandler repositories) {
         repositories?.each { repo ->
             if (repo instanceof MavenArtifactRepository) {
                 logger.info("${logPrefix} ${repoContext} repository '${repo.name}' '${repo.url}' found.")
+                final String effectiveRepoName = resolveRepoPropertyIfNeeded(repoContext, repo.name) ?: repo.name
+                if (effectiveRepoName != repo.name) {
+                    logger.info("${logPrefix} Resolved ${repoContext} repository name '${repo.name}' to '${effectiveRepoName}' for credentials lookup.")
+                }
                 mavenSettings.servers.each { server ->
-                    if (repo.name == server.id) {
+                    if (effectiveRepoName == server.id) {
                         addCredentials(server, repo)
                     }
                 }

--- a/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
+++ b/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
@@ -49,7 +49,7 @@ abstract class AbstractMavenSettingsPlugin {
 
     public static final String MAVEN_SETTINGS_EXTENSION_NAME = 'mavenSettings'
 
-    public static final String MAVEN_SETTINGS_REPO_NAME_PROPERTY_PREFIX = MAVEN_SETTINGS_EXTENSION_NAME + '@'
+    public static final String MAVEN_SETTINGS_REPO_NAME_PROPERTY_PREFIX = 'maven-settings.'
 
     public static final String MAVEN_SETTINGS_REPO_URL_PROPERTY_PREFIX = 'https://' + MAVEN_SETTINGS_REPO_NAME_PROPERTY_PREFIX
 

--- a/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
+++ b/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
@@ -38,7 +38,6 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
-import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ExtraPropertiesExtension
 
 import javax.annotation.Nullable
@@ -49,7 +48,9 @@ abstract class AbstractMavenSettingsPlugin {
 
     public static final String MAVEN_SETTINGS_EXTENSION_NAME = 'mavenSettings'
 
-    public static final String MAVEN_SETTINGS_REPO_NAME_PROPERTY_PREFIX = 'maven-settings.'
+    public static final String MAVEN_SETTINGS_PROFILE_PROPERTY_PREFIX = 'maven-settings.'
+
+    public static final String MAVEN_SETTINGS_REPO_NAME_PROPERTY_PREFIX = MAVEN_SETTINGS_PROFILE_PROPERTY_PREFIX
 
     public static final String MAVEN_SETTINGS_REPO_URL_PROPERTY_PREFIX = 'https://' + MAVEN_SETTINGS_REPO_NAME_PROPERTY_PREFIX
 
@@ -167,15 +168,16 @@ abstract class AbstractMavenSettingsPlugin {
     }
 
     private void applyProfile(Profile profile, MavenSettingsPluginExtension extension) {
+        final ExtraPropertiesExtension extraPropertiesExtension = scopeUtilizer.extensions.getByType(ExtraPropertiesExtension)
         logger.info("${logPrefix} Applying Maven profile ${profile.id}:")
         for (Entry entry : profile.properties) {
-            ExtensionContainer extensions = scopeUtilizer.extensions
             if (logger.isDebugEnabled()) {
                 logger.debug("${logPrefix}   Applying property '${entry.key}' with value '${entry.value}'.")
             } else {
                 logger.info("${logPrefix}   Applying property '${entry.key}'.")
             }
-            extensions.getByType(ExtraPropertiesExtension).set(entry.key.toString(), entry.value.toString())
+            extraPropertiesExtension.set(entry.key.toString(), entry.value.toString())
+            extraPropertiesExtension.set(MAVEN_SETTINGS_PROFILE_PROPERTY_PREFIX + entry.key.toString(), entry.value.toString())
         }
 
         if (extension.addRepositories) {

--- a/src/test/groovy/net/linguica/gradle/maven/settings/test/MavenSettingsProjectPluginTest.groovy
+++ b/src/test/groovy/net/linguica/gradle/maven/settings/test/MavenSettingsProjectPluginTest.groovy
@@ -366,7 +366,7 @@ class MavenSettingsProjectPluginTest extends AbstractMavenSettingsTest {
                 "custom1")
 
         assertThat(project.repositories
-                .findAll { it instanceof MavenArtifactRepository }
+                .withType(MavenArtifactRepository)
                 .collect { (it as MavenArtifactRepository).url.toString() })
                 .contains(
                         "https://repo.maven.apache.org/maven2/",
@@ -463,4 +463,52 @@ class MavenSettingsProjectPluginTest extends AbstractMavenSettingsTest {
                 })
     }
 
+    @Test
+    void resolvePropertiesInRepoNameAndUrl() {
+        def props = new Properties()
+        props.setProperty('repoId', 'myTestRepo')
+        props.setProperty('repoUrl', 'https://myTestHost/myTestRepo')
+        props.setProperty('repoUrl2', 'https://myTestHost/myTestRepo2')
+
+        withMavenSettings {
+            servers.add new Server(id: 'myTestRepo', username: TEST_USER_NAME, password: TEST_USER_PASSWORD)
+            servers.add new Server(id: 'myFixRepoId', username: TEST_USER_NAME + '2', password: TEST_USER_PASSWORD + '2')
+            profiles.add new Profile(id: TEST_PROFILE_ID, properties: props)
+        }
+
+        addPluginWithSettings()
+
+        project.with {
+            mavenSettings {
+                activeProfiles = [TEST_PROFILE_ID]
+            }
+
+            repositories {
+                maven {
+                    name = 'mavenSettings@repoId'
+                    url = 'https://mavenSettings@repoUrl'
+                }
+                maven {
+                    name = 'myFixRepoId'
+                    url = 'https://mavenSettings@repoUrl2'
+                }
+            }
+        }
+
+        project.evaluate()
+
+        assertThat(project.properties).containsEntry('repoId', 'myTestRepo')
+        assertThat(project.properties).containsEntry('repoUrl', 'https://myTestHost/myTestRepo')
+        assertThat(project.repositories.names).containsOnly('mavenSettings@repoId', 'myFixRepoId')
+        assertThat(project.repositories.withType(MavenArtifactRepository)
+                .collect { it.url.toString() })
+                .contains(
+                        new URI('https://myTestHost/myTestRepo').toString(),
+                        new URI('https://myTestHost/myTestRepo2').toString()
+                )
+        assertEquals(TEST_USER_NAME, project.repositories.getByName('mavenSettings@repoId').credentials.username)
+        assertEquals(TEST_USER_PASSWORD, project.repositories.getByName('mavenSettings@repoId').credentials.password)
+        assertEquals(TEST_USER_NAME + '2', project.repositories.myFixRepoId.credentials.username)
+        assertEquals(TEST_USER_PASSWORD + '2', project.repositories.myFixRepoId.credentials.password)
+    }
 }

--- a/src/test/groovy/net/linguica/gradle/maven/settings/test/MavenSettingsProjectPluginTest.groovy
+++ b/src/test/groovy/net/linguica/gradle/maven/settings/test/MavenSettingsProjectPluginTest.groovy
@@ -485,12 +485,12 @@ class MavenSettingsProjectPluginTest extends AbstractMavenSettingsTest {
 
             repositories {
                 maven {
-                    name = 'mavenSettings@repoId'
-                    url = 'https://mavenSettings@repoUrl'
+                    name = 'maven-settings.repoId'
+                    url = 'https://maven-settings.repoUrl'
                 }
                 maven {
                     name = 'myFixRepoId'
-                    url = 'https://mavenSettings@repoUrl2'
+                    url = 'https://maven-settings.repoUrl2'
                 }
             }
         }
@@ -499,15 +499,15 @@ class MavenSettingsProjectPluginTest extends AbstractMavenSettingsTest {
 
         assertThat(project.properties).containsEntry('repoId', 'myTestRepo')
         assertThat(project.properties).containsEntry('repoUrl', 'https://myTestHost/myTestRepo')
-        assertThat(project.repositories.names).containsOnly('mavenSettings@repoId', 'myFixRepoId')
+        assertThat(project.repositories.names).containsOnly('maven-settings.repoId', 'myFixRepoId')
         assertThat(project.repositories.withType(MavenArtifactRepository)
                 .collect { it.url.toString() })
                 .contains(
                         new URI('https://myTestHost/myTestRepo').toString(),
                         new URI('https://myTestHost/myTestRepo2').toString()
                 )
-        assertEquals(TEST_USER_NAME, project.repositories.getByName('mavenSettings@repoId').credentials.username)
-        assertEquals(TEST_USER_PASSWORD, project.repositories.getByName('mavenSettings@repoId').credentials.password)
+        assertEquals(TEST_USER_NAME, project.repositories.getByName('maven-settings.repoId').credentials.username)
+        assertEquals(TEST_USER_PASSWORD, project.repositories.getByName('maven-settings.repoId').credentials.password)
         assertEquals(TEST_USER_NAME + '2', project.repositories.myFixRepoId.credentials.username)
         assertEquals(TEST_USER_PASSWORD + '2', project.repositories.myFixRepoId.credentials.password)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving repository names and URLs from Maven settings.xml profile properties using prefix conventions: `mavenSettings@` for repository names and `https://mavenSettings@` for repository URLs in Gradle configurations.

* **Documentation**
  * Updated README with guidance on using profile properties to dynamically resolve repository configurations.

* **Tests**
  * Added test coverage for the new property resolution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->