### PR TITLE
Add git.commit.id to log prefix for SNAPSHOT build version

### DIFF
--- a/src/main/groovy/io/github/mhoffrog/gradle/maven/settings/utils/PluginResourcesUtil.groovy
+++ b/src/main/groovy/io/github/mhoffrog/gradle/maven/settings/utils/PluginResourcesUtil.groovy
@@ -58,6 +58,20 @@ class PluginResourcesUtil {
         return getProperty("plugin.nameInLogPrefix", true)
     }
 
+    static String getPluginBuildDirectory() {
+        return getProperty("plugin.buildDirectory", true)
+    }
+
+    static String getGitCommitIdShort() {
+        String gitCommitIdFull = getGitCommitIdFull()
+        int shortLen = 7
+        return gitCommitIdFull ? gitCommitIdFull.substring(0, Math.min(shortLen, gitCommitIdFull.length())) : ''
+    }
+
+    static String getGitCommitIdFull() {
+        return getProperty("git.commit.id", false) ?: ''
+    }
+
     static String getProperty(String key, boolean isMandatory = false) {
         String ret = pluginProperties.getProperty(key)
         if (!ret && isMandatory) {

--- a/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
+++ b/src/main/groovy/net/linguica/gradle/maven/settings/AbstractMavenSettingsPlugin.groovy
@@ -67,7 +67,10 @@ abstract class AbstractMavenSettingsPlugin {
     private Logger logger
 
     static {
-        LOG_PREFIX_TEMPLATE = "${PluginResourcesUtil.pluginNameInLogPrefix}[${LOG_PREFIX_SCOPE_TOKEN}] v${PluginResourcesUtil.pluginVersion}:"
+        final String pluginVersion = PluginResourcesUtil.pluginVersion
+        final boolean isSnapshotVersion = pluginVersion.endsWith('-SNAPSHOT')
+        final String gitCommitId = PluginResourcesUtil.gitCommitIdShort
+        LOG_PREFIX_TEMPLATE = "${PluginResourcesUtil.pluginNameInLogPrefix}[${LOG_PREFIX_SCOPE_TOKEN}] v${pluginVersion}${(isSnapshotVersion && gitCommitId) ? " #${gitCommitId}" : ''}:"
     }
 
     void apply(IGradlePluginScopeUtilizer scopeUtilizerParam) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added git commit metadata accessors for enhanced build tracking
  * Improved snapshot build logging with dynamic commit information
  * Expanded plugin resource configuration access for build directory settings

* **Refactor**
  * Enhanced log prefix formatting to conditionally include commit identifiers for snapshot versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->